### PR TITLE
Trim the cookie notice text

### DIFF
--- a/src/components/CookieNotice.js
+++ b/src/components/CookieNotice.js
@@ -6,7 +6,7 @@ function CookieNotice() {
   if (navigator.language.indexOf("de") > -1) {
     return (
       <CookieBanner
-        message="Unsere Website verwendet Cookies, um u.a. Funktionen für soziale Medien bereitzustellen und den Datenverkehr zu analysieren."
+        message="Unsere Website verwendet Cookies."
         buttonMessage="Okay, verstanden"
         onAccept={() => {}}
         cookie="user-has-accepted-cookies" 
@@ -20,7 +20,7 @@ function CookieNotice() {
   } else {
     return (
       <CookieBanner
-        message="Our site uses cookies to provide social media features and to analyse traffic."
+        message="Our site uses cookies."
         buttonMessage="Got it"
         onAccept={() => {}}
         cookie="user-has-accepted-cookies" 


### PR DESCRIPTION
## What type of PR is this?
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Trim the cookie text to better portray it on mobile devices. This is just a temporary solution and should be edited later with media queries.

## Mobile Screenshot
![Cookie notice banner on mobile devices](https://user-images.githubusercontent.com/42657842/66033750-326cc900-e508-11e9-8927-83930e59f6d0.png)
